### PR TITLE
stopped narrative control hover states on touch devices

### DIFF
--- a/less/narrative.less
+++ b/less/narrative.less
@@ -95,7 +95,7 @@
         z-index: 10;
         text-decoration: none;
         background-color:@button-color;
-        &:hover {
+        .no-touch &:hover {
             background-color:@button-hover-color;
             .icon {
                 color:@button-text-hover-color;


### PR DESCRIPTION
added .no-touch class to narrative control hover states to stop frequent
issue where narrative buttons would be blue and have hover states on
mobiles.